### PR TITLE
Dynamic Areas wrapped functions

### DIFF
--- a/src/main/java/net/gtaun/shoebill/streamer/Callbacks.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/Callbacks.java
@@ -5,6 +5,7 @@ import net.gtaun.shoebill.amx.AmxInstanceManager;
 import net.gtaun.shoebill.constant.WeaponModel;
 import net.gtaun.shoebill.data.Vector3D;
 import net.gtaun.shoebill.object.Player;
+import net.gtaun.shoebill.streamer.data.DynamicArea;
 import net.gtaun.shoebill.streamer.data.DynamicObject;
 import net.gtaun.shoebill.streamer.data.DynamicPickup;
 import net.gtaun.shoebill.streamer.event.*;
@@ -49,12 +50,21 @@ public class Callbacks {
                     new Vector3D((float) amxCallEvent.getParameters()[3], (float) amxCallEvent.getParameters()[4], (float) amxCallEvent.getParameters()[5]));
             eventManager.dispatchEvent(event, player, dynamicObject);
         }, "iiifff");
-        amxInstanceManager.hookCallback("OnPlayerPickUpDynamicPickup", amxCallEvent -> {
+
+        amxInstanceManager.hookCallback("OnPlayerEnterDynamicArea", amxCallEvent -> {
             Player player = Player.get((int) amxCallEvent.getParameters()[0]);
-            DynamicPickup pickup = DynamicPickup.get((int) amxCallEvent.getParameters()[1]);
-            PlayerPickUpDynamicPickupEvent event = new PlayerPickUpDynamicPickupEvent(player, pickup);
+            DynamicArea area = DynamicArea.get((int) amxCallEvent.getParameters()[1]);
+            PlayerEnterDynamicAreaEvent event = new PlayerEnterDynamicAreaEvent(player, area);
             eventManager.dispatchEvent(event);
         }, "ii");
+
+        amxInstanceManager.hookCallback("OnPlayerLeaveDynamicArea", amxCallEvent -> {
+            Player player = Player.get((int) amxCallEvent.getParameters()[0]);
+            DynamicArea area = DynamicArea.get((int) amxCallEvent.getParameters()[1]);
+            PlayerLeaveDynamicAreaEvent event = new PlayerLeaveDynamicAreaEvent(player, area);
+            eventManager.dispatchEvent(event);
+        }, "ii");
+
     }
 
     public static void unregisterHandlers() {
@@ -63,6 +73,8 @@ public class Callbacks {
         amxInstanceManager.unhookCallback("OnPlayerSelectDynamicObject");
         amxInstanceManager.unhookCallback("OnPlayerShootDynamicObject");
         amxInstanceManager.unhookCallback("OnPlayerPickUpDynamicPickup");
+        amxInstanceManager.unhookCallback("OnPlayerEnterDynamicArea");
+        amxInstanceManager.unhookCallback("OnPlayerLeaveDynamicArea");
     }
 
 }

--- a/src/main/java/net/gtaun/shoebill/streamer/Functions.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/Functions.java
@@ -67,6 +67,7 @@ public class Functions {
     private static AmxCallable createDynamicCircle;
     private static AmxCallable createDynamicSphere;
     private static AmxCallable createDynamicRectangle;
+    private static AmxCallable createDynamicCuboid;
     private static AmxCallable destroyDynamicArea;
     private static AmxCallable isValidDynamicArea;
     private static AmxCallable isPlayerInDynamicArea;
@@ -74,7 +75,7 @@ public class Functions {
     private static AmxCallable isAnyPlayerInDynamicArea;
     private static AmxCallable isAnyPlayerInAnyDynamicArea;
     private static AmxCallable isPointInDynamicArea;
-    private static AmxCallable IsPointInAnyDynamicArea;
+    private static AmxCallable isPointInAnyDynamicArea;
 
     //Streamer:
     private static AmxCallable update;
@@ -149,6 +150,7 @@ public class Functions {
             createDynamicCircle = instance.getNative("CreateDynamicCircle");
             createDynamicSphere = instance.getNative("CreateDynamicSphere");
             createDynamicRectangle = instance.getNative("CreateDynamicRectangle");
+            createDynamicCuboid = instance.getNative("CreateDynamicCuboid");
             destroyDynamicArea = instance.getNative("DestroyDynamicArea");
             isValidDynamicArea = instance.getNative("IsValidDynamicArea");
             isPlayerInDynamicArea = instance.getNative("IsPlayerInDynamicArea");
@@ -156,7 +158,7 @@ public class Functions {
             isAnyPlayerInDynamicArea = instance.getNative("IsAnyPlayerInDynamicArea");
             isAnyPlayerInAnyDynamicArea = instance.getNative("IsAnyPlayerInAnyDynamicArea");
             isPointInDynamicArea = instance.getNative("IsPointInDynamicArea");
-            IsPointInAnyDynamicArea = instance.getNative("IsPointInAnyDynamicArea");
+            isPointInAnyDynamicArea = instance.getNative("isPointInAnyDynamicArea");
         }
     }
 
@@ -425,6 +427,11 @@ public class Functions {
         return new DynamicRectangle(id, playerId);
     }
 
+    public static DynamicCuboid createDynamicCuboid(Area3D area, int worldId, int interiorId, int playerId) {
+        int id = (int) createDynamicCuboid.call(area.minX, area.minY, area.minZ, area.maxX, area.maxY, area.maxZ, worldId, interiorId, playerId);
+        return new DynamicCuboid(id, playerId);
+    }
+
     public static void destroyDynamicArea(DynamicArea area) {
         destroyDynamicArea.call(area.getId());
     }
@@ -454,6 +461,6 @@ public class Functions {
     }
 
     public static boolean IsPointInAnyDynamicArea(Vector3D point) {
-        return (int) isPointInDynamicArea.call(point.x, point.y, point.z) == 1;
+        return (int) isPointInAnyDynamicArea.call(point.x, point.y, point.z) == 1;
     }
 }

--- a/src/main/java/net/gtaun/shoebill/streamer/Functions.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/Functions.java
@@ -8,9 +8,7 @@ import net.gtaun.shoebill.amx.types.ReferenceInt;
 import net.gtaun.shoebill.amx.types.ReferenceString;
 import net.gtaun.shoebill.constant.MapIconStyle;
 import net.gtaun.shoebill.constant.ObjectMaterialSize;
-import net.gtaun.shoebill.data.Color;
-import net.gtaun.shoebill.data.Location;
-import net.gtaun.shoebill.data.Vector3D;
+import net.gtaun.shoebill.data.*;
 import net.gtaun.shoebill.exception.CreationFailedException;
 import net.gtaun.shoebill.object.Player;
 import net.gtaun.shoebill.streamer.data.*;
@@ -65,6 +63,19 @@ public class Functions {
     private static AmxCallable destroyDynamicMapIcon;
     private static AmxCallable isValidDynamicMapIcon;
 
+    //Areas:
+    private static AmxCallable createDynamicCircle;
+    private static AmxCallable createDynamicSphere;
+    private static AmxCallable createDynamicRectangle;
+    private static AmxCallable destroyDynamicArea;
+    private static AmxCallable isValidDynamicArea;
+    private static AmxCallable isPlayerInDynamicArea;
+    private static AmxCallable isPlayerInAnyDynamicArea;
+    private static AmxCallable isAnyPlayerInDynamicArea;
+    private static AmxCallable isAnyPlayerInAnyDynamicArea;
+    private static AmxCallable isPointInDynamicArea;
+    private static AmxCallable IsPointInAnyDynamicArea;
+
     //Streamer:
     private static AmxCallable update;
     private static AmxCallable updateEx;
@@ -76,6 +87,7 @@ public class Functions {
         findPickupFunctions(amxInstance);
         find3DTextLabelFunctions(amxInstance);
         findStreamerFunctions(amxInstance);
+        findAreaFunctions(amxInstance);
     }
 
     public static void unregisterHandlers() {
@@ -129,6 +141,22 @@ public class Functions {
             isValidDynamic3DTextLabel = instance.getNative("IsValidDynamic3DTextLabel");
             getDynamic3DTextLabelText = instance.getNative("GetDynamic3DTextLabelText");
             updateDynamic3DTextLabelText = instance.getNative("UpdateDynamic3DTextLabelText");
+        }
+    }
+
+    private static void findAreaFunctions(AmxInstance instance) {
+        if (createDynamicCircle == null) {
+            createDynamicCircle = instance.getNative("CreateDynamicCircle");
+            createDynamicSphere = instance.getNative("CreateDynamicSphere");
+            createDynamicRectangle = instance.getNative("CreateDynamicRectangle");
+            destroyDynamicArea = instance.getNative("DestroyDynamicArea");
+            isValidDynamicArea = instance.getNative("IsValidDynamicArea");
+            isPlayerInDynamicArea = instance.getNative("IsPlayerInDynamicArea");
+            isPlayerInAnyDynamicArea = instance.getNative("IsPlayerInAnyDynamicArea");
+            isAnyPlayerInDynamicArea = instance.getNative("IsAnyPlayerInDynamicArea");
+            isAnyPlayerInAnyDynamicArea = instance.getNative("IsAnyPlayerInAnyDynamicArea");
+            isPointInDynamicArea = instance.getNative("IsPointInDynamicArea");
+            IsPointInAnyDynamicArea = instance.getNative("IsPointInAnyDynamicArea");
         }
     }
 
@@ -376,5 +404,66 @@ public class Functions {
 
     public static boolean isValidDynamicMapIcon(DynamicMapIcon mapIcon) {
         return (boolean) isValidDynamicMapIcon.call(mapIcon.getId());
+    }
+
+     /*
+        private static AmxCallable createDynamicCircle;
+    private static AmxCallable createDynamicSphere;
+    private static AmxCallable createDynamicRectangle;
+    private static AmxCallable destroyDynamicArea;
+    private static AmxCallable isValidDynamicArea;
+    private static AmxCallable isPlayerInDynamicArea;
+    private static AmxCallable isPlayerInAnyDynamicArea;
+    private static AmxCallable isAnyPlayerInDynamicArea;
+    private static AmxCallable isAnyPlayerInAnyDynamicArea;
+    private static AmxCallable isPointInDynamicArea;
+    private static AmxCallable IsPointInAnyDynamicArea;
+         */
+
+    public static DynamicCircle createDynamicCircle(Vector2D location, float size, int worldId, int interiorId, int playerId) {
+        int id = (int) createDynamicCircle.call(location.x, location.y, size, worldId, interiorId, playerId);
+        return new DynamicCircle(id, playerId);
+    }
+
+    public static DynamicSphere createDynamicSphere(Vector3D location, float size, int worldId, int interiorId, int playerId) {
+        int id = (int) createDynamicSphere.call(location.x, location.y, location.z, size, worldId, interiorId, playerId);
+        return new DynamicSphere(id, playerId);
+    }
+
+    public static DynamicRectangle createDynamicRectangle(Area area, int worldId, int interiorId, int playerId) {
+        int id = (int) createDynamicRectangle.call(area.minX, area.minY, area.maxX, area.maxY, worldId, interiorId, playerId);
+        return new DynamicRectangle(id, playerId);
+    }
+
+    public static void destroyDynamicArea(DynamicArea area) {
+        destroyDynamicArea.call(area.getId());
+    }
+
+    public static boolean isValidDynamicArea(DynamicArea area) {
+        return (int) isValidDynamicArea.call(area.getId()) == 1;
+    }
+
+    public static boolean isPlayerInDynamicArea(int playerId, DynamicArea area) {
+        return (int) isPlayerInDynamicArea.call(playerId, area.getId(), 0) == 1;
+    }
+
+    public static boolean isPlayerInAnyDynamicArea(int playerId) {
+        return (int) isPlayerInAnyDynamicArea.call(playerId, 0) == 1;
+    }
+
+    public static boolean isAnyPlayerInDynamicArea(DynamicArea area) {
+        return (int) isAnyPlayerInDynamicArea.call(area.getId(), 0) == 1;
+    }
+
+    public static boolean isAnyPlayerInAnyDynamicArea() {
+        return (int) isAnyPlayerInAnyDynamicArea.call(0) == 1;
+    }
+
+    public static boolean isPointInDynamicArea(DynamicArea area, Vector3D point) {
+        return (int) isPointInDynamicArea.call(area.getId(), point.x, point.y, point.z) == 1;
+    }
+
+    public static boolean IsPointInAnyDynamicArea(Vector3D point) {
+        return (int) isPointInDynamicArea.call(point.x, point.y, point.z) == 1;
     }
 }

--- a/src/main/java/net/gtaun/shoebill/streamer/Functions.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/Functions.java
@@ -391,6 +391,8 @@ public class Functions {
         updateEx.call(player.getId(), x, y, z, worldid, interiorid, streamerType.getValue());
     }
 
+    //MapIcons:
+
     public static DynamicMapIcon createDynamicMapIcon(Location location, int type, Color color, int playerid, float streamDistance, MapIconStyle style) {
         int id = (int) createDynamicMapIcon.call(location.x, location.y, location.z, type,
                 color.getValue(), location.worldId, location.interiorId, playerid, streamDistance, style.getValue());
@@ -406,19 +408,7 @@ public class Functions {
         return (boolean) isValidDynamicMapIcon.call(mapIcon.getId());
     }
 
-     /*
-        private static AmxCallable createDynamicCircle;
-    private static AmxCallable createDynamicSphere;
-    private static AmxCallable createDynamicRectangle;
-    private static AmxCallable destroyDynamicArea;
-    private static AmxCallable isValidDynamicArea;
-    private static AmxCallable isPlayerInDynamicArea;
-    private static AmxCallable isPlayerInAnyDynamicArea;
-    private static AmxCallable isAnyPlayerInDynamicArea;
-    private static AmxCallable isAnyPlayerInAnyDynamicArea;
-    private static AmxCallable isPointInDynamicArea;
-    private static AmxCallable IsPointInAnyDynamicArea;
-         */
+    //Areas:
 
     public static DynamicCircle createDynamicCircle(Vector2D location, float size, int worldId, int interiorId, int playerId) {
         int id = (int) createDynamicCircle.call(location.x, location.y, size, worldId, interiorId, playerId);

--- a/src/main/java/net/gtaun/shoebill/streamer/Functions.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/Functions.java
@@ -407,7 +407,7 @@ public class Functions {
     }
 
     public static boolean isValidDynamicMapIcon(DynamicMapIcon mapIcon) {
-        return (boolean) isValidDynamicMapIcon.call(mapIcon.getId());
+        return (int) isValidDynamicMapIcon.call(mapIcon.getId()) == 1;
     }
 
     //Areas:

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicArea.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicArea.java
@@ -1,0 +1,98 @@
+package net.gtaun.shoebill.streamer.data;
+
+import net.gtaun.shoebill.data.Vector3D;
+import net.gtaun.shoebill.object.Destroyable;
+import net.gtaun.shoebill.object.Player;
+import net.gtaun.shoebill.streamer.Functions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by Valeriy on 18/4/2016.
+ */
+public class DynamicArea implements Destroyable {
+    static Collection<DynamicArea> areas;
+
+    static {
+        areas = new ArrayList<>();
+    }
+
+    private int id, playerId;
+
+    public DynamicArea(int id, int playerId) {
+        this.id = id;
+        this.playerId = playerId;
+    }
+
+    public static Set<DynamicArea> get() {
+        return new HashSet<>(areas);
+    }
+
+    public static DynamicArea get(int id) {
+        for (DynamicArea area : areas) {
+            if(area.getId() == id) {
+                return area;
+            }
+        }
+        return null;
+    }
+
+    static boolean addArea(DynamicArea area) {
+        return areas.add(area);
+    }
+
+    public boolean isPlayerInRange(Player player) {
+        return Functions.isPlayerInDynamicArea(player.getId(), this);
+    }
+
+    public boolean isPointInRange(Vector3D point) {
+        return Functions.isPointInDynamicArea(this, point);
+    }
+
+    // TODO: implement
+    public void attachToPlayer() {
+        throw new UnsupportedOperationException();
+    }
+
+    // TODO: implement
+    public void attachToObject() {
+        throw new UnsupportedOperationException();
+    }
+
+    // TODO: implement
+    public void attachToVehicle() {
+        throw new UnsupportedOperationException();
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getPlayerId() {
+        return playerId;
+    }
+
+    @Override
+    public void destroy() {
+        if(isDestroyed()) {
+            selfRemove();
+            return;
+        }
+
+        Functions.destroyDynamicArea(this);
+        this.id = -1;
+        selfRemove();
+    }
+
+    private void selfRemove() {
+        areas.remove(this);
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return false;
+    }
+}

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicCircle.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicCircle.java
@@ -11,6 +11,10 @@ public class DynamicCircle extends DynamicArea {
         super(id, playerId);
     }
 
+    public static DynamicCircle create(Vector2D location, float size) {
+        return create(location, size, -1, -1, -1);
+    }
+
     public static DynamicCircle create(Vector2D location, float size, int worldId, int interiorId, int playerId) {
         DynamicCircle circle = Functions.createDynamicCircle(location, size, worldId, interiorId, playerId);
         DynamicArea.addArea(circle);

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicCircle.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicCircle.java
@@ -1,0 +1,19 @@
+package net.gtaun.shoebill.streamer.data;
+
+import net.gtaun.shoebill.data.Vector2D;
+import net.gtaun.shoebill.streamer.Functions;
+
+/**
+ * Created by Valeriy on 18/4/2016.
+ */
+public class DynamicCircle extends DynamicArea {
+    public DynamicCircle(int id, int playerId) {
+        super(id, playerId);
+    }
+
+    public static DynamicCircle create(Vector2D location, float size, int worldId, int interiorId, int playerId) {
+        DynamicCircle circle = Functions.createDynamicCircle(location, size, worldId, interiorId, playerId);
+        DynamicArea.addArea(circle);
+        return circle;
+    }
+}

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicCuboid.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicCuboid.java
@@ -1,0 +1,23 @@
+package net.gtaun.shoebill.streamer.data;
+
+import net.gtaun.shoebill.data.Area3D;
+import net.gtaun.shoebill.streamer.Functions;
+
+/**
+ * Created by Valeriy on 18/4/2016.
+ */
+public class DynamicCuboid extends DynamicArea {
+    public DynamicCuboid(int id, int playerId) {
+        super(id, playerId);
+    }
+
+    public static DynamicCuboid create(Area3D area) {
+        return create(area, -1, -1, -1);
+    }
+
+    public static DynamicCuboid create(Area3D area, int worldId, int interiorId, int playerId) {
+        DynamicCuboid cuboid = Functions.createDynamicCuboid(area, worldId, interiorId, playerId);
+        DynamicArea.addArea(cuboid);
+        return cuboid;
+    }
+}

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicRectangle.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicRectangle.java
@@ -1,0 +1,19 @@
+package net.gtaun.shoebill.streamer.data;
+
+import net.gtaun.shoebill.data.Area;
+import net.gtaun.shoebill.streamer.Functions;
+
+/**
+ * Created by Valeriy on 18/4/2016.
+ */
+public class DynamicRectangle extends DynamicArea {
+    public DynamicRectangle(int id, int playerId) {
+        super(id, playerId);
+    }
+
+    public static DynamicRectangle create(Area area, int worldId, int interiorId, int playerId) {
+        DynamicRectangle rectangle = Functions.createDynamicRectangle(area, worldId, interiorId, playerId);
+        DynamicArea.addArea(rectangle);
+        return rectangle;
+    }
+}

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicRectangle.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicRectangle.java
@@ -11,6 +11,10 @@ public class DynamicRectangle extends DynamicArea {
         super(id, playerId);
     }
 
+    public static DynamicRectangle create(Area area) {
+        return create(area, -1, -1, -1);
+    }
+
     public static DynamicRectangle create(Area area, int worldId, int interiorId, int playerId) {
         DynamicRectangle rectangle = Functions.createDynamicRectangle(area, worldId, interiorId, playerId);
         DynamicArea.addArea(rectangle);

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicSphere.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicSphere.java
@@ -11,6 +11,10 @@ public class DynamicSphere extends DynamicArea {
         super(id, playerId);
     }
 
+    public static DynamicSphere create(Vector3D location, float size) {
+        return create(location, size, -1, -1, -1);
+    }
+
     public static DynamicSphere create(Vector3D location, float size, int worldId, int interiorId, int playerId) {
         DynamicSphere sphere = Functions.createDynamicSphere(location, size, worldId, interiorId, playerId);
         DynamicArea.addArea(sphere);

--- a/src/main/java/net/gtaun/shoebill/streamer/data/DynamicSphere.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/data/DynamicSphere.java
@@ -1,0 +1,19 @@
+package net.gtaun.shoebill.streamer.data;
+
+import net.gtaun.shoebill.data.Vector3D;
+import net.gtaun.shoebill.streamer.Functions;
+
+/**
+ * Created by Valeriy on 18/4/2016.
+ */
+public class DynamicSphere extends DynamicArea {
+    public DynamicSphere(int id, int playerId) {
+        super(id, playerId);
+    }
+
+    public static DynamicSphere create(Vector3D location, float size, int worldId, int interiorId, int playerId) {
+        DynamicSphere sphere = Functions.createDynamicSphere(location, size, worldId, interiorId, playerId);
+        DynamicArea.addArea(sphere);
+        return sphere;
+    }
+}

--- a/src/main/java/net/gtaun/shoebill/streamer/event/PlayerEnterDynamicAreaEvent.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/event/PlayerEnterDynamicAreaEvent.java
@@ -1,0 +1,22 @@
+package net.gtaun.shoebill.streamer.event;
+
+import net.gtaun.shoebill.event.player.PlayerEvent;
+import net.gtaun.shoebill.object.Player;
+import net.gtaun.shoebill.streamer.data.DynamicArea;
+import net.gtaun.util.event.Event;
+
+/**
+ * Created by Valeriy on 18/4/2016.
+ */
+public class PlayerEnterDynamicAreaEvent extends PlayerEvent {
+    DynamicArea dynamicArea;
+
+    public PlayerEnterDynamicAreaEvent(Player player, DynamicArea dynamicArea) {
+        super(player);
+        this.dynamicArea = dynamicArea;
+    }
+
+    public DynamicArea getDynamicArea() {
+        return dynamicArea;
+    }
+}

--- a/src/main/java/net/gtaun/shoebill/streamer/event/PlayerLeaveDynamicAreaEvent.java
+++ b/src/main/java/net/gtaun/shoebill/streamer/event/PlayerLeaveDynamicAreaEvent.java
@@ -1,0 +1,21 @@
+package net.gtaun.shoebill.streamer.event;
+
+import net.gtaun.shoebill.event.player.PlayerEvent;
+import net.gtaun.shoebill.object.Player;
+import net.gtaun.shoebill.streamer.data.DynamicArea;
+
+/**
+ * Created by Valeriy on 18/4/2016.
+ */
+public class PlayerLeaveDynamicAreaEvent extends PlayerEvent {
+    DynamicArea dynamicArea;
+
+    public PlayerLeaveDynamicAreaEvent(Player player, DynamicArea dynamicArea) {
+        super(player);
+        this.dynamicArea = dynamicArea;
+    }
+
+    public DynamicArea getDynamicArea() {
+        return dynamicArea;
+    }
+}


### PR DESCRIPTION
Added support for streamer's Dynamic Areas. For now, it is possible to create Circle, Sphere, Rectangle and Cuboid. Methods attachToPlayer/Object/Vehicle() are not implemented yet.
Also, there is small fix with method isValidDynamicMapIcon - it returned boolean result of call() method, but actually the method returns integer. Solution: cast result to int and compare the result with 1.
More details can be seen in commits.
